### PR TITLE
Build and deploy init container

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -43,10 +43,24 @@ jobs:
       packages: write
     name: Deploy Container
     needs: [ set-env ]
+    strategy:
+      matrix:
+        stage: [
+          "final",
+          "initcontainer"
+        ]
+        include:
+          - stage: "final"
+            tag-prefix: ""
+          - stage: "initcontainer"
+            tag-prefix: "init-"
     uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build-push-deploy.yml@v3.1.0
     with:
       docker-image-name: 'rise-app'
       docker-build-file-name: './Dockerfile'
+      docker-build-target: ${{ matrix.stage }}
+      docker-tag-prefix: ${{ matrix.tag-prefix }}
+      import-without-deploy: ${{ matrix.stage == 'initcontainer' }}
       environment: ${{ needs.set-env.outputs.environment }}
       annotate-release: false
     secrets:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,6 +10,12 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        stage: [
+          "final",
+          "initcontainer"
+        ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -23,4 +29,5 @@ jobs:
           secrets: github_token=${{ secrets.GITHUB_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha
+          target: ${{ matrix.stage }}
           push: false

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -8,6 +8,12 @@ jobs:
   scan:
     name: Scan for CVEs
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        stage: [
+          "final",
+          "initcontainer"
+        ]
     outputs:
       image: ${{ steps.build.outputs.imageid }}
     steps:
@@ -25,15 +31,16 @@ jobs:
           load: true
           cache-from: type=gha
           cache-to: type=gha
+          target: ${{ matrix.stage }}
           push: false
 
       - name: Export docker image as tar
-        run: docker save -o ${{ github.ref_name }}.tar ${{ steps.build.outputs.imageid }}
+        run: docker save -o ${{ matrix.stage }}.tar ${{ steps.build.outputs.imageid }}
 
       - name: Scan Docker image for CVEs
         uses: aquasecurity/trivy-action@0.24.0
         with:
-          input: ${{ github.ref_name }}.tar
+          input: ${{ matrix.stage }}.tar
           format: 'sarif'
           output: 'trivy-results.sarif'
           limit-severities-for-sarif: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,15 +28,15 @@ RUN ["dotnet", "publish", "Dfe.RegionalImprovementForStandardsAndExcellence", "-
 
 # Generate an Entity Framework bundle
 FROM build AS efbuilder
-WORKDIR /build/src
 ENV PATH=$PATH:/root/.dotnet/tools
-RUN ["dotnet", "tool", "install", "--global", "dotnet-ef"]
 RUN ["mkdir", "/sql"]
-RUN ["dotnet", "ef", "migrations", "bundle", "-r", "linux-x64", "--configuration", "Release", "-p", "Dfe.RegionalImprovementForStandardsAndExcellence.Infrastructure", "--no-build", "-o", "/sql/migratedb"]
+RUN ["dotnet", "tool", "install", "--global", "dotnet-ef"]
+RUN ["dotnet", "ef", "migrations", "bundle", "-r", "linux-x64", "-p", "Dfe.RegionalImprovementForStandardsAndExcellence", "--configuration", "Release", "--no-build", "-o", "/sql/migratedb"]
 
 # Create a runtime environment for Entity Framework
 FROM "mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION}-azurelinux3.0" AS initcontainer
 WORKDIR /sql
+COPY --from=efbuilder /app /Dfe.RegionalImprovementForStandardsAndExcellence
 COPY --from=efbuilder /sql /sql
 RUN chown "$APP_UID" "/sql" -R
 USER $APP_UID

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN chown "$APP_UID" "/sql" -R
 USER $APP_UID
 
 # Build a runtime environment
-FROM "mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION}-azurelinux3.0" AS base
+FROM "mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION}-azurelinux3.0" AS final
 WORKDIR /app
 LABEL org.opencontainers.image.source="https://github.com/DFE-Digital/regional-improvement-for-standards-and-excellence"
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -187,6 +187,7 @@ No resources.
 | <a name="input_enable_dns_zone"></a> [enable\_dns\_zone](#input\_enable\_dns\_zone) | Conditionally create a DNS zone | `bool` | n/a | yes |
 | <a name="input_enable_event_hub"></a> [enable\_event\_hub](#input\_enable\_event\_hub) | Send Azure Container App logs to an Event Hub sink | `bool` | `false` | no |
 | <a name="input_enable_health_insights_api"></a> [enable\_health\_insights\_api](#input\_enable\_health\_insights\_api) | Deploys a Function App that exposes the last 3 HTTP Web Tests via an API endpoint. 'enable\_app\_insights\_integration' and 'enable\_monitoring' must be set to 'true'. | `bool` | `false` | no |
+| <a name="input_enable_init_container"></a> [enable\_init\_container](#input\_enable\_init\_container) | Deploy an Init Container. Init containers run before the primary app container and are used to perform initialization tasks such as downloading data or preparing the environment | `bool` | `false` | no |
 | <a name="input_enable_logstash_consumer"></a> [enable\_logstash\_consumer](#input\_enable\_logstash\_consumer) | Create an Event Hub consumer group for Logstash | `bool` | `false` | no |
 | <a name="input_enable_monitoring"></a> [enable\_monitoring](#input\_enable\_monitoring) | Create an App Insights instance and notification group for the Container App | `bool` | n/a | yes |
 | <a name="input_enable_mssql_database"></a> [enable\_mssql\_database](#input\_enable\_mssql\_database) | Set to true to create an Azure SQL server/database, with a private endpoint within the virtual network | `bool` | n/a | yes |
@@ -198,6 +199,8 @@ No resources.
 | <a name="input_health_insights_api_cors_origins"></a> [health\_insights\_api\_cors\_origins](#input\_health\_insights\_api\_cors\_origins) | List of hostnames that are permitted to contact the Health insights API | `list(string)` | <pre>[<br/>  "*"<br/>]</pre> | no |
 | <a name="input_health_insights_api_ipv4_allow_list"></a> [health\_insights\_api\_ipv4\_allow\_list](#input\_health\_insights\_api\_ipv4\_allow\_list) | List of IPv4 addresses that are permitted to contact the Health insights API | `list(string)` | `[]` | no |
 | <a name="input_image_name"></a> [image\_name](#input\_image\_name) | Image name | `string` | n/a | yes |
+| <a name="input_init_container_command"></a> [init\_container\_command](#input\_init\_container\_command) | Container command for the Init Container | `list(any)` | `[]` | no |
+| <a name="input_init_container_image"></a> [init\_container\_image](#input\_init\_container\_image) | Image name for the Init Container. Leave blank to use the same Container image from the primary app | `string` | `""` | no |
 | <a name="input_key_vault_access_ipv4"></a> [key\_vault\_access\_ipv4](#input\_key\_vault\_access\_ipv4) | List of IPv4 Addresses that are permitted to access the Key Vault | `list(string)` | n/a | yes |
 | <a name="input_monitor_email_receivers"></a> [monitor\_email\_receivers](#input\_monitor\_email\_receivers) | A list of email addresses that should be notified by monitoring alerts | `list(string)` | n/a | yes |
 | <a name="input_monitor_endpoint_healthcheck"></a> [monitor\_endpoint\_healthcheck](#input\_monitor\_endpoint\_healthcheck) | Specify a route that should be monitored for a 200 OK status | `string` | n/a | yes |

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -35,6 +35,10 @@ module "azure_container_apps_hosting" {
   health_insights_api_ipv4_allow_list    = local.health_insights_api_ipv4_allow_list
   enable_container_app_file_share        = local.enable_container_app_file_share
 
+  enable_init_container  = local.enable_init_container
+  init_container_image   = local.init_container_image
+  init_container_command = local.init_container_command
+
   enable_cdn_frontdoor                            = local.enable_cdn_frontdoor
   cdn_frontdoor_forwarding_protocol               = local.cdn_frontdoor_forwarding_protocol
   cdn_frontdoor_origin_host_header_override       = local.cdn_frontdoor_origin_host_header_override

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -15,6 +15,9 @@ locals {
   container_max_replicas                          = var.container_max_replicas
   container_scale_http_concurrency                = var.container_scale_http_concurrency
   container_port                                  = var.container_port
+  enable_init_container                           = var.enable_init_container
+  init_container_image                            = var.init_container_image
+  init_container_command                          = var.init_container_command
   enable_event_hub                                = var.enable_event_hub
   enable_logstash_consumer                        = var.enable_logstash_consumer
   eventhub_export_log_analytics_table_names       = var.eventhub_export_log_analytics_table_names

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -435,3 +435,21 @@ variable "storage_account_public_access_enabled" {
   type        = bool
   default     = true
 }
+
+variable "enable_init_container" {
+  description = "Deploy an Init Container. Init containers run before the primary app container and are used to perform initialization tasks such as downloading data or preparing the environment"
+  type        = bool
+  default     = false
+}
+
+variable "init_container_image" {
+  description = "Image name for the Init Container. Leave blank to use the same Container image from the primary app"
+  type        = string
+  default     = ""
+}
+
+variable "init_container_command" {
+  description = "Container command for the Init Container"
+  type        = list(any)
+  default     = []
+}


### PR DESCRIPTION
* Build and push two images for the app, one being the main runtime and the other being an initContainer that only runs EF migrations
* Add Terraform configuration to allow us to launch the initContainer in Azure
* Update the Docker CI workflows to support testing both stages of the image