### PR TITLE
Docker layer improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,336 @@
+## Source: https://raw.githubusercontent.com/dotnet/runtime/refs/heads/main/.dockerignore
+
+### VisualStudio ###
+
+# Tool Runtime Dir
+**/.dotnet/
+**/.packages/
+**/.tools/
+
+# User-specific files
+**/*.suo
+**/*.user
+**/*.userosscache
+**/*.sln.docstates
+
+# Build results
+**/artifacts/
+**/.idea/
+**/[Dd]ebug/
+**/[Dd]ebugPublic/
+**/[Rr]elease/
+**/[Rr]eleases/
+**/bld/
+**/[Bb]in/
+**/[Oo]bj/
+**/msbuild.log
+**/msbuild.err
+**/msbuild.wrn
+**/msbuild.binlog
+**/.deps/
+**/.dirstamp
+**/.libs/
+**/*.lo
+**/*.o
+
+# Cross building rootfs
+**/cross/rootfs/
+**/cross/android-rootfs/
+
+# Visual Studio
+**/.vs/
+
+# Ionide
+**/.ionide/
+
+# MSTest test Results
+**/[Tt]est[Rr]esult*/
+**/[Bb]uild[Ll]og.*
+
+#NUNIT
+**/*.VisualState.xml
+**/TestResult.xml
+
+# Build Results of an ATL Project
+**/[Dd]ebugPS/
+**/[Rr]eleasePS/
+**/dlldata.c
+
+**/*_i.c
+**/*_p.c
+**/*.ilk
+**/*.meta
+**/*.obj
+**/*.pch
+**/*.pdb
+!**/_.pdb
+**/*.pgc
+**/*.pgd
+**/*.rsp
+**/*.sbr
+**/*.tlb
+**/*.tli
+**/*.tlh
+**/*.tmp
+**/*.tmp_proj
+**/*.log
+**/*.vspscc
+**/*.vssscc
+**/.builds
+**/*.pidb
+**/*.svclog
+**/*.scc
+
+# Chutzpah Test files
+**/_Chutzpah*
+
+# Visual C++ cache files
+**/ipch/
+**/*.aps
+**/*.ncb
+**/*.opendb
+**/*.opensdf
+**/*.sdf
+**/*.cachefile
+**/*.VC.db
+
+# Visual Studio profiler
+**/*.psess
+**/*.vsp
+**/*.vspx
+
+# TFS 2012 Local Workspace
+**/$tf/
+
+# Guidance Automation Toolkit
+**/*.gpState
+
+# ReSharper is a .NET coding add-in
+**/_ReSharper*/
+**/*.[Rr]e[Ss]harper
+**/*.DotSettings.user
+
+# JustCode is a .NET coding addin-in
+**/.JustCode
+
+# TeamCity is a build add-in
+**/_TeamCity*
+
+# DotCover is a Code Coverage Tool
+**/*.dotCover
+
+# NCrunch
+**/_NCrunch_*
+**/.*crunch*.local.xml
+
+# MightyMoose
+**/*.mm.*
+**/AutoTest.Net/
+
+# Web workbench (sass)
+**/.sass-cache/
+
+# Installshield output folder
+**/[Ee]xpress/
+
+# DocProject is a documentation generator add-in
+**/DocProject/buildhelp/
+**/DocProject/Help/*.HxT
+**/DocProject/Help/*.HxC
+**/DocProject/Help/*.hhc
+**/DocProject/Help/*.hhk
+**/DocProject/Help/*.hhp
+**/DocProject/Help/Html2
+**/DocProject/Help/html
+
+# Publish Web Output
+**/*.[Pp]ublish.xml
+**/*.azurePubxml
+**/*.pubxml
+**/*.publishproj
+
+# NuGet Packages
+**/*.nupkg
+**/*.nuget.g.props
+**/*.nuget.g.targets
+**/*.nuget.cache
+**/**/packages/*
+**/project.lock.json
+**/project.assets.json
+**/*.nuget.dgspec.json
+
+# Windows Azure Build Output
+**/csx/
+**/*.build.csdef
+
+# Windows Store app package directory
+**/AppPackages/
+
+# Others
+**/*.Cache
+**/ClientBin/
+**/[Ss]tyle[Cc]op.*
+**/~$*
+**/*.dbmdl
+**/*.dbproj.schemaview
+**/*.pfx
+**/*.publishsettings
+**/node_modules/
+**/*.metaproj
+**/*.metaproj.tmp
+**/bin.localpkg/
+
+# RIA/Silverlight projects
+**/Generated_Code/
+
+# Backup & report files from converting an old project file
+# to a newer Visual Studio version. Backup files are not needed,
+# because we have git ;-)
+**/_UpgradeReport_Files/
+**/Backup*/
+**/UpgradeLog*.XML
+**/UpgradeLog*.htm
+
+# SQL Server files
+**/*.mdf
+**/*.ldf
+
+# Business Intelligence projects
+**/*.rdl.data
+**/*.bim.layout
+**/*.bim_*.settings
+
+# Microsoft Fakes
+**/FakesAssemblies/
+
+# C/C++ extension for Visual Studio Code
+**/browse.VC.db
+# Local settings folder for Visual Studio Code
+**/**/.vscode/**
+!**/**/.vscode/c_cpp_properties.json
+
+### MonoDevelop ###
+
+**/*.pidb
+**/*.userprefs
+
+### Windows ###
+
+# Windows image file caches
+**/Thumbs.db
+**/ehthumbs.db
+
+# Folder config file
+**/Desktop.ini
+
+# Recycle Bin used on file shares
+**/$RECYCLE.BIN/
+
+# Windows Installer files
+**/*.cab
+**/*.msi
+**/*.msm
+**/*.msp
+
+# Windows shortcuts
+**/*.lnk
+
+### Linux ###
+
+**/*~
+
+# KDE directory preferences
+**/.directory
+
+### OSX ###
+
+**/.DS_Store
+**/.AppleDouble
+**/.LSOverride
+
+# Icon must end with two \r
+**/Icon
+
+# Thumbnails
+**/._*
+
+# Files that might appear on external disk
+**/.Spotlight-V100
+**/.Trashes
+
+# Directories potentially created on remote AFP share
+**/.AppleDB
+**/.AppleDesktop
+**/Network Trash Folder
+**/Temporary Items
+**/.apdisk
+
+# vim temporary files
+**/[._]*.s[a-w][a-z]
+**/[._]s[a-w][a-z]
+**/*.un~
+**/Session.vim
+**/.netrwhist
+**/*~
+
+# Visual Studio Code
+**/.vscode/
+
+# Private test configuration and binaries.
+**/config.ps1
+**/**/IISApplications
+
+# VS debug support files
+**/launchSettings.json
+
+# Snapcraft files
+**/.snapcraft
+**/*.snap
+**/parts/
+**/prime/
+**/stage/
+
+# CLR prebuilt generated files
+!**/src/pal/prebuilt/idl/*_i.c
+
+# Valid 'debug' folder, that contains CLR debugging code
+!**/src/**/debug
+
+# Ignore folders created by the CLR test build
+**/TestWrappers_x64_[d|D]ebug
+**/TestWrappers_x64_[c|C]hecked
+**/TestWrappers_x64_[r|R]elease
+**/TestWrappers_x86_[d|D]ebug
+**/TestWrappers_x86_[c|C]hecked
+**/TestWrappers_x86_[r|R]elease
+**/TestWrappers_arm_[d|D]ebug
+**/TestWrappers_arm_[c|C]hecked
+**/TestWrappers_arm_[r|R]elease
+**/TestWrappers_arm64_[d|D]ebug
+**/TestWrappers_arm64_[c|C]hecked
+**/TestWrappers_arm64_[r|R]elease
+**/tests/src/common/test_runtime/project.json
+
+**/Vagrantfile
+**/.vagrant
+
+# CMake files
+**/CMakeFiles/
+**/cmake_install.cmake
+**/CMakeCache.txt
+**/Makefile
+
+# Cross compilation
+**/cross/rootfs/*
+**/cross/android-rootfs/*
+# add x86 as it is ignored in 'Build results'
+!**/cross/x86
+
+#python import files
+**/*.pyc
+
+# JIT32 files
+**/src/jit32
+
+# performance testing sandbox
+**/sandbox

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,18 +13,33 @@ ARG NODEJS_VERSION_MAJOR=22
 # Build the app using the dotnet SDK
 FROM "mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}-azurelinux3.0" AS build
 WORKDIR /build
-COPY ./Dfe.RegionalImprovementForStandardsAndExcellence.sln /build
 COPY ./Directory.Build.props /build
-COPY ./src/ /build/src
 COPY ./scripts/docker-entrypoint.sh /app/docker-entrypoint.sh
+
+## START: Restore Packages
+ARG PROJECT_NAME="Dfe.RegionalImprovementForStandardsAndExcellence"
+COPY ./${PROJECT_NAME}.sln ./Directory.Build.props ./
+COPY ./src/${PROJECT_NAME}/${PROJECT_NAME}.Frontend.csproj                      ./src/${PROJECT_NAME}/
+COPY ./src/${PROJECT_NAME}.Api/${PROJECT_NAME}.Api.csproj                       ./src/${PROJECT_NAME}.Api/
+COPY ./src/${PROJECT_NAME}.Api.Client/${PROJECT_NAME}.Api.Client.csproj         ./src/${PROJECT_NAME}.Api.Client/
+COPY ./src/${PROJECT_NAME}.Application/${PROJECT_NAME}.Application.csproj       ./src/${PROJECT_NAME}.Application/
+COPY ./src/${PROJECT_NAME}.Domain/${PROJECT_NAME}.Domain.csproj                 ./src/${PROJECT_NAME}.Domain/
+COPY ./src/${PROJECT_NAME}.Infrastructure/${PROJECT_NAME}.Infrastructure.csproj ./src/${PROJECT_NAME}.Infrastructure/
+COPY ./src/${PROJECT_NAME}.Utils/${PROJECT_NAME}.Utils.csproj                   ./src/${PROJECT_NAME}.Utils/
+
+COPY ./src/Tests/${PROJECT_NAME}.Api.Tests.Integration/${PROJECT_NAME}.Api.Tests.Integration.csproj ./src/Tests/${PROJECT_NAME}.Api.Tests.Integration/
+COPY ./src/Tests/${PROJECT_NAME}.Application.Tests/${PROJECT_NAME}.Application.Tests.csproj         ./src/Tests/${PROJECT_NAME}.Application.Tests/
+COPY ./src/Tests/${PROJECT_NAME}.Domain.Tests/${PROJECT_NAME}.Domain.Tests.csproj                   ./src/Tests/${PROJECT_NAME}.Domain.Tests/
+COPY ./src/Tests/${PROJECT_NAME}.Tests.Common/${PROJECT_NAME}.Tests.Common.csproj                   ./src/Tests/${PROJECT_NAME}.Tests.Common/
 
 # Mount GitHub Token as a Docker secret so that NuGet Feed can be accessed
 RUN --mount=type=secret,id=github_token dotnet nuget add source --username USERNAME --password $(cat /run/secrets/github_token) --store-password-in-clear-text --name github "https://nuget.pkg.github.com/DFE-Digital/index.json"
-
 RUN ["dotnet", "restore", "Dfe.RegionalImprovementForStandardsAndExcellence.sln"]
+## END: Restore Packages
+
 WORKDIR /build/src
-RUN ["dotnet", "build", "Dfe.RegionalImprovementForStandardsAndExcellence", "--no-restore", "-c", "Release"]
-RUN ["dotnet", "publish", "Dfe.RegionalImprovementForStandardsAndExcellence", "--no-build", "-o", "/app"]
+COPY ./src/ .
+RUN ["dotnet", "publish", "Dfe.RegionalImprovementForStandardsAndExcellence", "-c", "Release", "--no-restore", "-o", "/app"]
 
 # Generate an Entity Framework bundle
 FROM build AS efbuilder
@@ -36,7 +51,7 @@ RUN ["dotnet", "ef", "migrations", "bundle", "-r", "linux-x64", "-p", "Dfe.Regio
 # Create a runtime environment for Entity Framework
 FROM "mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION}-azurelinux3.0" AS initcontainer
 WORKDIR /sql
-COPY --from=efbuilder /app /Dfe.RegionalImprovementForStandardsAndExcellence
+COPY --from=efbuilder /app/appsettings.json /Dfe.RegionalImprovementForStandardsAndExcellence/
 COPY --from=efbuilder /sql /sql
 RUN chown "$APP_UID" "/sql" -R
 USER $APP_UID


### PR DESCRIPTION
Splitting NuGet package restoration into it's own docker layers means that for the majority of times the image is built we can safely cache and skip the entire `dotnet restore` stage and jump directly to `dotnet build`.

Additionally, slimming down the final initcontainer stage by only shipping the EF Bundle and the appsettings.json reduces the image size by ~300mb