### PR TITLE
Add missing services to frontend project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ COPY ./src/${PROJECT_NAME}.Utils/${PROJECT_NAME}.Utils.csproj                   
 COPY ./src/Tests/${PROJECT_NAME}.Api.Tests.Integration/${PROJECT_NAME}.Api.Tests.Integration.csproj ./src/Tests/${PROJECT_NAME}.Api.Tests.Integration/
 COPY ./src/Tests/${PROJECT_NAME}.Application.Tests/${PROJECT_NAME}.Application.Tests.csproj         ./src/Tests/${PROJECT_NAME}.Application.Tests/
 COPY ./src/Tests/${PROJECT_NAME}.Domain.Tests/${PROJECT_NAME}.Domain.Tests.csproj                   ./src/Tests/${PROJECT_NAME}.Domain.Tests/
+COPY ./src/Tests/${PROJECT_NAME}.Frontend.Tests/${PROJECT_NAME}.Frontend.Tests.csproj                   ./src/Tests/${PROJECT_NAME}.Frontend.Tests/
 COPY ./src/Tests/${PROJECT_NAME}.Tests.Common/${PROJECT_NAME}.Tests.Common.csproj                   ./src/Tests/${PROJECT_NAME}.Tests.Common/
 
 # Mount GitHub Token as a Docker secret so that NuGet Feed can be accessed

--- a/src/Dfe.RegionalImprovementForStandardsAndExcellence.Infrastructure/Dfe.RegionalImprovementForStandardsAndExcellence.Infrastructure.csproj
+++ b/src/Dfe.RegionalImprovementForStandardsAndExcellence.Infrastructure/Dfe.RegionalImprovementForStandardsAndExcellence.Infrastructure.csproj
@@ -13,6 +13,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.8" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="3.3.1" />
   </ItemGroup>

--- a/src/Dfe.RegionalImprovementForStandardsAndExcellence.Infrastructure/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Dfe.RegionalImprovementForStandardsAndExcellence.Infrastructure/InfrastructureServiceCollectionExtensions.cs
@@ -31,7 +31,15 @@ namespace Microsoft.Extensions.DependencyInjection
             // Utils
             services.AddScoped<IDateTimeProvider, DateTimeProvider>();
 
+            // Health check
+            AddInfrastructureHealthCheck(services);
+
             return services;
+        }
+
+        public static void AddInfrastructureHealthCheck(this IServiceCollection services) {
+            services.AddHealthChecks()
+                .AddDbContextCheck<RegionalImprovementForStandardsAndExcellenceContext>("RISE Database");
         }
     }
 }

--- a/src/Dfe.RegionalImprovementForStandardsAndExcellence/Program.cs
+++ b/src/Dfe.RegionalImprovementForStandardsAndExcellence/Program.cs
@@ -74,6 +74,15 @@ builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
         options.Scope.Add("User.Read");
     });
 
+// Enforce HTTPS in ASP.NET Core
+// @link https://learn.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?
+builder.Services.AddHsts(options =>
+{
+    options.Preload = true;
+    options.IncludeSubDomains = true;
+    options.MaxAge = TimeSpan.FromDays(365);
+});
+
 builder.Services.Configure<CookieAuthenticationOptions>(CookieAuthenticationDefaults.AuthenticationScheme,
    options =>
    {

--- a/src/Dfe.RegionalImprovementForStandardsAndExcellence/Program.cs
+++ b/src/Dfe.RegionalImprovementForStandardsAndExcellence/Program.cs
@@ -139,6 +139,8 @@ if (!app.Environment.IsDevelopment())
     app.UseExceptionHandler("/Error");
     // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
     app.UseHsts();
+} else {
+    app.UseDeveloperExceptionPage();
 }
 
 app.UseHttpsRedirection();

--- a/src/Dfe.RegionalImprovementForStandardsAndExcellence/Program.cs
+++ b/src/Dfe.RegionalImprovementForStandardsAndExcellence/Program.cs
@@ -86,7 +86,7 @@ builder.Services.Configure<CookieAuthenticationOptions>(CookieAuthenticationDefa
    options =>
    {
        options.AccessDeniedPath = "/access-denied";
-       options.Cookie.Name = ".Rise.Login";
+       options.Cookie.Name = ".RISE.Login";
        options.Cookie.HttpOnly = true;
        options.Cookie.IsEssential = true;
        options.ExpireTimeSpan = _authenticationExpiration;

--- a/src/Dfe.RegionalImprovementForStandardsAndExcellence/Program.cs
+++ b/src/Dfe.RegionalImprovementForStandardsAndExcellence/Program.cs
@@ -1,6 +1,4 @@
-
 using Microsoft.AspNetCore.CookiePolicy;
-
 using Dfe.Academisation.CorrelationIdMiddleware;
 using Dfe.RegionalImprovementForStandardsAndExcellence.Frontend.Models;
 using Dfe.RegionalImprovementForStandardsAndExcellence.Frontend.Services;
@@ -8,11 +6,10 @@ using Dfe.RegionalImprovementForStandardsAndExcellence.Frontend.Services.AzureAd
 using Dfe.RegionalImprovementForStandardsAndExcellence.Frontend.Services.Http;
 using Microsoft.Identity.Web;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.Extensions.Configuration;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authentication.Cookies;
-using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpOverrides;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/src/Dfe.RegionalImprovementForStandardsAndExcellence/Program.cs
+++ b/src/Dfe.RegionalImprovementForStandardsAndExcellence/Program.cs
@@ -124,6 +124,15 @@ builder.Services.AddAuthorization(options =>
 
 var app = builder.Build();
 
+var forwardOptions = new ForwardedHeadersOptions
+{
+    ForwardedHeaders = ForwardedHeaders.All,
+    RequireHeaderSymmetry = false
+};
+forwardOptions.KnownNetworks.Clear();
+forwardOptions.KnownProxies.Clear();
+app.UseForwardedHeaders(forwardOptions);
+
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())
 {

--- a/src/Dfe.RegionalImprovementForStandardsAndExcellence/Program.cs
+++ b/src/Dfe.RegionalImprovementForStandardsAndExcellence/Program.cs
@@ -41,6 +41,8 @@ builder.Services.AddSession(options =>
     //  options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
 });
 
+builder.Services.AddHealthChecks();
+
 builder.Services.AddScoped(sp => sp.GetService<IHttpContextAccessor>()?.HttpContext?.Session);
 // Add services to the container.
 builder.Services.AddRazorPages(options =>
@@ -162,6 +164,8 @@ app.UseEndpoints(endpoints =>
     endpoints.MapRazorPages();
     endpoints.MapControllerRoute("default", "{controller}/{action}/");
 });
+
+app.UseHealthChecks("/health");
 
 app.Run();
 

--- a/src/Dfe.RegionalImprovementForStandardsAndExcellence/Program.cs
+++ b/src/Dfe.RegionalImprovementForStandardsAndExcellence/Program.cs
@@ -41,8 +41,6 @@ builder.Services.AddSession(options =>
     //  options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
 });
 
-builder.Services.AddHealthChecks();
-
 builder.Services.AddScoped(sp => sp.GetService<IHttpContextAccessor>()?.HttpContext?.Session);
 // Add services to the container.
 builder.Services.AddRazorPages(options =>


### PR DESCRIPTION
- Sets correct HSTS Header values
- Adds support for using X-Forwarded-Host instead of Host which will fix what URL the app will use during SSO
- Use Developer debug page when in dev environment
- Set up /health endpoint as a Health Check and register the Database as a checkable service