### PR TITLE
Fixing some minor casing and naming content issues

### DIFF
--- a/src/Dfe.RegionalImprovementForStandardsAndExcellence/Pages/AboutTheSchool/Index.cshtml
+++ b/src/Dfe.RegionalImprovementForStandardsAndExcellence/Pages/AboutTheSchool/Index.cshtml
@@ -4,7 +4,7 @@
 @model Dfe.RegionalImprovementForStandardsAndExcellence.Frontend.Pages.AboutTheSchool.IndexModel
 @{
     Model.SetErrorPage(Links.SchoolList.Index.Page);
-    ViewData["Title"] = "About The School";
+    ViewData["Title"] = "About the school";
 }
 
 @section BeforeMain

--- a/src/Dfe.RegionalImprovementForStandardsAndExcellence/Pages/Shared/_ProjectHeader.cshtml
+++ b/src/Dfe.RegionalImprovementForStandardsAndExcellence/Pages/Shared/_ProjectHeader.cshtml
@@ -48,7 +48,7 @@
          <partial name="_OfstedJudgement" model="Model.LeadershipAndManagement"/>
       </p>
       <p class="govuk-body govuk-!-margin-bottom-1">
-         <b>Assigned Adviser:</b>
+         <b>Advised by:</b>
          @if (@Model.AssignedAdviserFullName == null || string.IsNullOrWhiteSpace(@Model.AssignedAdviserFullName))
          {
             <span data-id="assigned-user" class="empty">Empty</span>

--- a/src/Dfe.RegionalImprovementForStandardsAndExcellence/Pages/Shared/_ProjectListFilters.cshtml
+++ b/src/Dfe.RegionalImprovementForStandardsAndExcellence/Pages/Shared/_ProjectListFilters.cshtml
@@ -58,7 +58,7 @@
             }
             @if (Model.SelectedLocalAuthorities.Length > 0)
             {
-                <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Local Authority</h3>
+                <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Local authority</h3>
 
                 <ul class="moj-filter-tags">
                     @{
@@ -108,7 +108,7 @@
 
                 <div class="govuk-form-group">
                     <label class="govuk-label govuk-label--m" for="projects">
-                        Search for projects
+                        Search for schools
                     </label>
                     <span class="govuk-hint">You can search by school name, academy name and URN</span>
                     <input id="Title" name="Title" asp-for="Title" type="text" class="govuk-input" aria-describedby="filter-project-title-hint"
@@ -182,7 +182,7 @@
                                 <div class="govuk-accordion__section-header">
                                     <h2 class="govuk-accordion__section-heading">
                                         <span class="govuk-accordion__section-button" id="accordion-local-authorities-heading" data-cy="select-projectlist-filter-local-authority">
-                                            Local Authority
+                                            Local authority
                                         </span>
                                     </h2>
                                 </div>

--- a/src/Dfe.RegionalImprovementForStandardsAndExcellence/Pages/Shared/_ProjectListRows.cshtml
+++ b/src/Dfe.RegionalImprovementForStandardsAndExcellence/Pages/Shared/_ProjectListRows.cshtml
@@ -21,7 +21,7 @@
                     <span id="@("urn-" + index)"><strong>URN:</strong> @project.SchoolUrn</span>
                 </div>
                 <div id="@("localauthority-" + project.Id)" class="govuk-!-margin-top-1">
-                    <strong>Local Authority:</strong>
+                    <strong>Local authority:</strong>
                     @if (@project.LocalAuthority.IsEmpty())
                     {
                         <span class="empty">Empty</span>

--- a/src/Dfe.RegionalImprovementForStandardsAndExcellence/Pages/Shared/_SubMenu.cshtml
+++ b/src/Dfe.RegionalImprovementForStandardsAndExcellence/Pages/Shared/_SubMenu.cshtml
@@ -10,7 +10,7 @@
             <sub-menu-link class="moj-sub-navigation__link"
                            asp-page="@Links.AboutTheSchool.Index.Page"
                            asp-route-id="@id">
-                About The School
+                About the school
             </sub-menu-link>
         </li>
         <li class="moj-sub-navigation__item">

--- a/src/Dfe.RegionalImprovementForStandardsAndExcellence/Pages/TaskList/Index.cshtml
+++ b/src/Dfe.RegionalImprovementForStandardsAndExcellence/Pages/TaskList/Index.cshtml
@@ -35,7 +35,7 @@
                 <li class="app-task-list__item">
                     <span class="app-task-list__task-name" data-cy="task-name">
                         <a class="govuk-link" asp-page="@Links.TaskList.RecordTheSchoolResponse.Page" asp-route-id="@Model.SupportProject.Id" aria-describedby="record-school-response-status" data-cy="record-school-response">
-                            Record the School's Response
+                            Record the school's response
                         </a>
                     </span>
                     <partial name="Shared/_TaskListStatus" model="@Model.RecordTheSchoolResponseTaskListStatus" />


### PR DESCRIPTION
## Story 

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_backlogs/backlog/Manage%20School%20Improvement%20(MSI)/Epics/?workitem=199086

## Changes

This work covers minor changes to some casing and naming issues @SteveMilnes spotted during a recent demo of the product.

1. About The School becomes `About the school` 
2. Record the School's Response becomes `Record the school's response`
3. Search for projects becomes `Search for schools`
4. Local Authority becomes `Local authority`
5. Assigned Adviser becomes `Advised by`