### PR TITLE
Display error page if any error occurs

### DIFF
--- a/src/Dfe.ManageSchoolImprovement/Pages/Errors/Index.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/Errors/Index.cshtml
@@ -1,0 +1,24 @@
+﻿@page
+@using System.Net
+@model Dfe.ManageSchoolImprovement.Frontend.Pages.Errors.IndexModel
+@{
+    ViewData["Title"] = @Model.ErrorMessage;
+}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l" id="error-heading">@Model.ErrorMessage</h1>
+        @if (Model.ErrorCode == StatusCodes.Status404NotFound)
+        {
+            <p class="govuk-body">
+                If you typed the web address, check it is correct.
+            </p>
+            <p class="govuk-body">
+                If you pasted the web address, check you copied the entire address.
+            </p>
+        }
+        else
+        {
+            <p class="govuk-body">Try again later.</p>
+        }
+    </div>
+</div>

--- a/src/Dfe.ManageSchoolImprovement/Pages/Errors/Index.cshtml.cs
+++ b/src/Dfe.ManageSchoolImprovement/Pages/Errors/Index.cshtml.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Dfe.ManageSchoolImprovement.Frontend.Pages.Errors
+{
+    public class IndexModel : PageModel
+    {
+        public string ErrorMessage { get; private set; } = "Sorry, there is a problem with the service";
+        public int? ErrorCode { get; private set; } = null;
+        public void OnGet(int? statusCode = null)
+        {
+            ManageErrors(statusCode);
+        }
+
+        public void OnPost(int? statusCode = null)
+        {
+            ManageErrors(statusCode);
+        }
+
+        private void ManageErrors(int? statusCode)
+        {
+            
+            if (!statusCode.HasValue)
+            {
+                ManageUnhandledErrors();
+                return;
+            }
+
+            ErrorMessage = statusCode.Value switch
+            {
+                404 => "Page not found",
+                500 => "Internal server error",
+                501 => "Not implemented",
+                _ => $"Error {statusCode}"
+            };
+            ErrorCode = statusCode;
+        }
+
+        private void ManageUnhandledErrors()
+        {
+            var unhandledError = HttpContext.Features.Get<IExceptionHandlerPathFeature>()?.Error;
+
+            // Thrown by RedirectToPage when the name of the page is incorrect.
+            if (unhandledError is InvalidOperationException && unhandledError.Message.Contains("no page named", StringComparison.CurrentCultureIgnoreCase))
+            {
+                ErrorMessage = "Page not found";
+                HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+            }
+        }
+    }
+}

--- a/src/Dfe.ManageSchoolImprovement/Program.cs
+++ b/src/Dfe.ManageSchoolImprovement/Program.cs
@@ -136,7 +136,7 @@ app.UseForwardedHeaders(forwardOptions);
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())
 {
-    app.UseExceptionHandler("/Error");
+    app.UseExceptionHandler("/Errors");
     // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
     app.UseHsts();
 }
@@ -144,6 +144,7 @@ else
 {
     app.UseDeveloperExceptionPage();
 }
+app.UseStatusCodePagesWithReExecute("/Errors", "?statusCode={0}");
 
 app.UseSecurityHeaders(SecurityHeadersDefinitions.GetHeaderPolicyCollection(app.Environment.IsDevelopment()));
 app.UseHttpsRedirection();
@@ -153,6 +154,7 @@ app.UseAuthentication();
 app.UseAuthorization();
 app.UseMiddleware<CorrelationIdMiddleware>();
 app.UseCookiePolicy(new CookiePolicyOptions { Secure = CookieSecurePolicy.Always, HttpOnly = HttpOnlyPolicy.Always });
+
 app.UseEndpoints(endpoints =>
 {
     endpoints.MapGet("/", context =>

--- a/src/Tests/Dfe.ManageSchoolImprovement.Frontend.Tests/Pages/Errors/IndexTests.cs
+++ b/src/Tests/Dfe.ManageSchoolImprovement.Frontend.Tests/Pages/Errors/IndexTests.cs
@@ -1,0 +1,107 @@
+﻿using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Dfe.ManageSchoolImprovement.Frontend.Pages.Errors;
+using Microsoft.AspNetCore.Routing;
+
+namespace Dfe.ManageSchoolImprovement.Frontend.Tests.Pages.Errors
+{
+    public class IndexTests
+    {
+        private readonly Mock<HttpContext> _httpContextMock;
+        private readonly IndexModel _model;
+
+        public IndexTests()
+        {
+            _httpContextMock = new Mock<HttpContext>();
+
+            ActionContext actionContext = new(_httpContextMock.Object, new RouteData(), new PageActionDescriptor(), new ModelStateDictionary());
+            PageContext pageContext = new(actionContext);
+            _model = new IndexModel { PageContext = pageContext };
+        }
+
+        [Theory]
+        [InlineData(404, "Page not found")]
+        [InlineData(500, "Internal server error")]
+        [InlineData(501, "Not implemented")]
+        [InlineData(99999, "Error 99999")]
+        public void OnGet_WhenResponseHasAStatusCode_SetsMessageCorrectly(int statusCode, string expectedMessage)
+        {
+            _model.OnGet(statusCode);
+
+            Assert.Equal(_model.ErrorMessage, expectedMessage);
+        }
+
+        [Fact]
+        public void OnGet_WhenUnhandledError_HasDefaultMessage()
+        {
+            Mock<IFeatureCollection> mockIFeatureCollection = new();
+            mockIFeatureCollection.Setup(collection => collection.Get<IExceptionHandlerPathFeature>())
+               .Returns(new ExceptionHandlerFeature { Error = new Exception() });
+            _httpContextMock.Setup(context => context.Features).Returns(mockIFeatureCollection.Object);
+
+            _model.OnGet();
+
+            Assert.Equal("Sorry, there is a problem with the service", _model.ErrorMessage);
+        }
+
+        [Fact]
+        public void OnGet_WhenUnhandledNoPageNamedError_SetsPageNotFoundMessageAndStatus()
+        {
+            Mock<IFeatureCollection> mockIFeatureCollection = new();
+            mockIFeatureCollection.Setup(collection => collection.Get<IExceptionHandlerPathFeature>())
+               .Returns(new ExceptionHandlerFeature { Error = new InvalidOperationException("No page named") });
+            _httpContextMock.Setup(context => context.Features).Returns(mockIFeatureCollection.Object);
+            _httpContextMock.SetupSet(context => context.Response.StatusCode = 404).Verifiable();
+
+            _model.OnGet();
+             
+            Assert.Equal("Page not found", _model.ErrorMessage);
+            _httpContextMock.Verify();
+        }
+
+        [Theory]
+        [InlineData(404, "Page not found")]
+        [InlineData(500, "Internal server error")]
+        [InlineData(501, "Not implemented")]
+        [InlineData(99999, "Error 99999")]
+        public void OnPost_WhenResponseHasAStatusCode_SetsMessageCorrectly(int statusCode, string expectedMessage)
+        {
+            _model.OnPost(statusCode);
+
+            Assert.Equal(_model.ErrorMessage, expectedMessage);
+        }
+
+        [Fact]
+        public void OnPost_WhenUnhandledError_HasDefaultMessage()
+        {
+            Mock<IFeatureCollection> mockIFeatureCollection = new();
+            mockIFeatureCollection.Setup(collection => collection.Get<IExceptionHandlerPathFeature>())
+               .Returns(new ExceptionHandlerFeature { Error = new Exception() });
+            _httpContextMock.Setup(context => context.Features).Returns(mockIFeatureCollection.Object);
+
+            _model.OnPost();
+
+            Assert.Equal("Sorry, there is a problem with the service", _model.ErrorMessage);
+        }
+
+        [Fact]
+        public void OnPost_WhenUnhandledNoPageNamedError_SetsPageNotFoundMessageAndStatus()
+        {
+            Mock<IFeatureCollection> mockIFeatureCollection = new();
+            mockIFeatureCollection.Setup(collection => collection.Get<IExceptionHandlerPathFeature>())
+               .Returns(new ExceptionHandlerFeature { Error = new InvalidOperationException("No page named") });
+            _httpContextMock.Setup(context => context.Features).Returns(mockIFeatureCollection.Object);
+            _httpContextMock.SetupSet(context => context.Response.StatusCode = 404).Verifiable();
+
+            _model.OnPost();
+
+            Assert.Equal("Page not found", _model.ErrorMessage);
+            _httpContextMock.Verify();
+        }
+    }
+}


### PR DESCRIPTION
Display Page not found if no URL is matched
Display Service error page if service throws an unhandled exception.